### PR TITLE
Properly exported symbols from library.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   VERSION ${PROJECT_VER}
   SOVERSION ${PROJECT_APIVER}
 )
+target_compile_definitions("${PROJECT_NAME}" PRIVATE "-DHTS_EXPORTS=1")
 
 # hts_engine binary
 add_executable(hts_engine bin/hts_engine.c)

--- a/src/include/HTS_engine.h
+++ b/src/include/HTS_engine.h
@@ -57,16 +57,24 @@ HTS_ENGINE_H_START;
 
 #include <stdio.h>
 
-#ifndef HTS_ENGINE_DLLEXPORT_H_
-#define HTS_ENGINE_DLLEXPORT_H_
-
-#ifndef DLLEXPORT
-#  ifdef _WIN32
-#      define DLLEXPORT __declspec(dllexport)
-#    else
-#      define DLLEXPORT
-#  endif
+#if defined(MSC_VER)
+    #define HTS_EXPORT_API __declspec(HTS_API)
+    #define HTS_IMPORT_API __declspec(dllimport)
+#else
+  #if defined(_WIN32) && _WIN32
+    #define HTS_EXPORT_API __attribute__((HTS_API))
+    #define HTS_IMPORT_API __attribute__((dllimport))
+  #else
+    #define HTS_EXPORT_API __attribute__((visibility("default")))
+    #define HTS_IMPORT_API
+  #endif
 #endif
+
+
+#ifdef HTS_EXPORTS
+#  define HTS_API HTS_EXPORT_API
+#else
+#  define HTS_API HTS_IMPORT_API
 #endif
 
 /* common ---------------------------------------------------------- */
@@ -316,169 +324,169 @@ typedef struct _HTS_Engine {
 /* engine method --------------------------------------------------- */
 
 /* HTS_Engine_initialize: initialize engine */
-DLLEXPORT void HTS_Engine_initialize(HTS_Engine * engine);
+HTS_API void HTS_Engine_initialize(HTS_Engine * engine);
 
 /* HTS_Engine_load: load HTS voices */
-DLLEXPORT HTS_Boolean HTS_Engine_load(HTS_Engine * engine, char **voices, size_t num_voices);
+HTS_API HTS_Boolean HTS_Engine_load(HTS_Engine * engine, char **voices, size_t num_voices);
 
 /* HTS_Engine_set_sampling_frequency: set sampling fraquency */
-DLLEXPORT void HTS_Engine_set_sampling_frequency(HTS_Engine * engine, size_t i);
+HTS_API void HTS_Engine_set_sampling_frequency(HTS_Engine * engine, size_t i);
 
 /* HTS_Engine_get_sampling_frequency: get sampling frequency */
-DLLEXPORT size_t HTS_Engine_get_sampling_frequency(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_sampling_frequency(HTS_Engine * engine);
 
 /* HTS_Engine_set_fperiod: set frame period */
-DLLEXPORT void HTS_Engine_set_fperiod(HTS_Engine * engine, size_t i);
+HTS_API void HTS_Engine_set_fperiod(HTS_Engine * engine, size_t i);
 
 /* HTS_Engine_get_fperiod: get frame period */
-DLLEXPORT size_t HTS_Engine_get_fperiod(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_fperiod(HTS_Engine * engine);
 
 /* HTS_Engine_set_audio_buff_size: set audio buffer size */
-DLLEXPORT void HTS_Engine_set_audio_buff_size(HTS_Engine * engine, size_t i);
+HTS_API void HTS_Engine_set_audio_buff_size(HTS_Engine * engine, size_t i);
 
 /* HTS_Engine_get_audio_buff_size: get audio buffer size */
-DLLEXPORT size_t HTS_Engine_get_audio_buff_size(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_audio_buff_size(HTS_Engine * engine);
 
 /* HTS_Engine_set_stop_flag: set stop flag */
-DLLEXPORT void HTS_Engine_set_stop_flag(HTS_Engine * engine, HTS_Boolean b);
+HTS_API void HTS_Engine_set_stop_flag(HTS_Engine * engine, HTS_Boolean b);
 
 /* HTS_Engine_get_stop_flag: get stop flag */
-DLLEXPORT HTS_Boolean HTS_Engine_get_stop_flag(HTS_Engine * engine);
+HTS_API HTS_Boolean HTS_Engine_get_stop_flag(HTS_Engine * engine);
 
 /* HTS_Engine_set_volume: set volume in db */
-DLLEXPORT void HTS_Engine_set_volume(HTS_Engine * engine, double f);
+HTS_API void HTS_Engine_set_volume(HTS_Engine * engine, double f);
 
 /* HTS_Engine_get_volume: get volume in db */
-DLLEXPORT double HTS_Engine_get_volume(HTS_Engine * engine);
+HTS_API double HTS_Engine_get_volume(HTS_Engine * engine);
 
 /* HTS_Egnine_set_msd_threshold: set MSD threshold */
-DLLEXPORT void HTS_Engine_set_msd_threshold(HTS_Engine * engine, size_t stream_index, double f);
+HTS_API void HTS_Engine_set_msd_threshold(HTS_Engine * engine, size_t stream_index, double f);
 
 /* HTS_Engine_get_msd_threshold: get MSD threshold */
-DLLEXPORT double HTS_Engine_get_msd_threshold(HTS_Engine * engine, size_t stream_index);
+HTS_API double HTS_Engine_get_msd_threshold(HTS_Engine * engine, size_t stream_index);
 
 /* HTS_Engine_set_gv_weight: set GV weight */
-DLLEXPORT void HTS_Engine_set_gv_weight(HTS_Engine * engine, size_t stream_index, double f);
+HTS_API void HTS_Engine_set_gv_weight(HTS_Engine * engine, size_t stream_index, double f);
 
 /* HTS_Engine_get_gv_weight: get GV weight */
-DLLEXPORT double HTS_Engine_get_gv_weight(HTS_Engine * engine, size_t stream_index);
+HTS_API double HTS_Engine_get_gv_weight(HTS_Engine * engine, size_t stream_index);
 
 /* HTS_Engine_set_speed: set speech speed */
-DLLEXPORT void HTS_Engine_set_speed(HTS_Engine * engine, double f);
+HTS_API void HTS_Engine_set_speed(HTS_Engine * engine, double f);
 
 /* HTS_Engine_set_phoneme_alignment_flag: set flag for using phoneme alignment in label */
-DLLEXPORT void HTS_Engine_set_phoneme_alignment_flag(HTS_Engine * engine, HTS_Boolean b);
+HTS_API void HTS_Engine_set_phoneme_alignment_flag(HTS_Engine * engine, HTS_Boolean b);
 
 /* HTS_Engine_set_alpha: set alpha */
-DLLEXPORT void HTS_Engine_set_alpha(HTS_Engine * engine, double f);
+HTS_API void HTS_Engine_set_alpha(HTS_Engine * engine, double f);
 
 /* HTS_Engine_get_alpha: get alpha */
-DLLEXPORT double HTS_Engine_get_alpha(HTS_Engine * engine);
+HTS_API double HTS_Engine_get_alpha(HTS_Engine * engine);
 
 /* HTS_Engine_set_beta: set beta */
-DLLEXPORT void HTS_Engine_set_beta(HTS_Engine * engine, double f);
+HTS_API void HTS_Engine_set_beta(HTS_Engine * engine, double f);
 
 /* HTS_Engine_get_beta: get beta */
-DLLEXPORT double HTS_Engine_get_beta(HTS_Engine * engine);
+HTS_API double HTS_Engine_get_beta(HTS_Engine * engine);
 
 /* HTS_Engine_add_half_tone: add half tone */
-DLLEXPORT void HTS_Engine_add_half_tone(HTS_Engine * engine, double f);
+HTS_API void HTS_Engine_add_half_tone(HTS_Engine * engine, double f);
 
 /* HTS_Engine_set_duration_interpolation_weight: set interpolation weight for duration */
-DLLEXPORT void HTS_Engine_set_duration_interpolation_weight(HTS_Engine * engine, size_t voice_index, double f);
+HTS_API void HTS_Engine_set_duration_interpolation_weight(HTS_Engine * engine, size_t voice_index, double f);
 
 /* HTS_Engine_get_duration_interpolation_weight: get interpolation weight for duration */
-DLLEXPORT double HTS_Engine_get_duration_interpolation_weight(HTS_Engine * engine, size_t voice_index);
+HTS_API double HTS_Engine_get_duration_interpolation_weight(HTS_Engine * engine, size_t voice_index);
 
 /* HTS_Engine_set_parameter_interpolation_weight: set interpolation weight for parameter */
-DLLEXPORT void HTS_Engine_set_parameter_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index, double f);
+HTS_API void HTS_Engine_set_parameter_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index, double f);
 
 /* HTS_Engine_get_parameter_interpolation_weight: get interpolation weight for parameter */
-DLLEXPORT double HTS_Engine_get_parameter_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index);
+HTS_API double HTS_Engine_get_parameter_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index);
 
 /* HTS_Engine_set_gv_interpolation_weight: set interpolation weight for GV */
-DLLEXPORT void HTS_Engine_set_gv_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index, double f);
+HTS_API void HTS_Engine_set_gv_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index, double f);
 
 /* HTS_Engine_get_gv_interpolation_weight: get interpolation weight for GV */
-DLLEXPORT double HTS_Engine_get_gv_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index);
+HTS_API double HTS_Engine_get_gv_interpolation_weight(HTS_Engine * engine, size_t voice_index, size_t stream_index);
 
 /* HTS_Engine_get_total_state: get total number of state */
-DLLEXPORT size_t HTS_Engine_get_total_state(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_total_state(HTS_Engine * engine);
 
 /* HTS_Engine_set_state_mean: set mean value of state */
-DLLEXPORT void HTS_Engine_set_state_mean(HTS_Engine * engine, size_t stream_index, size_t state_index, size_t vector_index, double f);
+HTS_API void HTS_Engine_set_state_mean(HTS_Engine * engine, size_t stream_index, size_t state_index, size_t vector_index, double f);
 
 /* HTS_Engine_get_state_mean: get mean value of state */
-DLLEXPORT double HTS_Engine_get_state_mean(HTS_Engine * engine, size_t stream_index, size_t state_index, size_t vector_index);
+HTS_API double HTS_Engine_get_state_mean(HTS_Engine * engine, size_t stream_index, size_t state_index, size_t vector_index);
 
 /* HTS_Engine_get_state_duration: get state duration */
-DLLEXPORT size_t HTS_Engine_get_state_duration(HTS_Engine * engine, size_t state_index);
+HTS_API size_t HTS_Engine_get_state_duration(HTS_Engine * engine, size_t state_index);
 
 /* HTS_Engine_get_nvoices: get number of voices */
-DLLEXPORT size_t HTS_Engine_get_nvoices(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_nvoices(HTS_Engine * engine);
 
 /* HTS_Engine_get_nstream: get number of stream */
-DLLEXPORT size_t HTS_Engine_get_nstream(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_nstream(HTS_Engine * engine);
 
 /* HTS_Engine_get_nstate: get number of state */
-DLLEXPORT size_t HTS_Engine_get_nstate(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_nstate(HTS_Engine * engine);
 
 /* HTS_Engine_get_fullcontext_label_format: get full context label format */
-DLLEXPORT const char *HTS_Engine_get_fullcontext_label_format(HTS_Engine * engine);
+HTS_API const char *HTS_Engine_get_fullcontext_label_format(HTS_Engine * engine);
 
 /* HTS_Engine_get_fullcontext_label_version: get full context label version */
-DLLEXPORT const char *HTS_Engine_get_fullcontext_label_version(HTS_Engine * engine);
+HTS_API const char *HTS_Engine_get_fullcontext_label_version(HTS_Engine * engine);
 
 /* HTS_Engine_get_total_frame: get total number of frame */
-DLLEXPORT size_t HTS_Engine_get_total_frame(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_total_frame(HTS_Engine * engine);
 
 /* HTS_Engine_get_nsamples: get number of samples */
-DLLEXPORT size_t HTS_Engine_get_nsamples(HTS_Engine * engine);
+HTS_API size_t HTS_Engine_get_nsamples(HTS_Engine * engine);
 
 /* HTS_Engine_get_generated_parameter: output generated parameter */
-DLLEXPORT double HTS_Engine_get_generated_parameter(HTS_Engine * engine, size_t stream_index, size_t frame_index, size_t vector_index);
+HTS_API double HTS_Engine_get_generated_parameter(HTS_Engine * engine, size_t stream_index, size_t frame_index, size_t vector_index);
 
 /* HTS_Engine_get_generated_speech: output generated speech */
-DLLEXPORT double HTS_Engine_get_generated_speech(HTS_Engine * engine, size_t index);
+HTS_API double HTS_Engine_get_generated_speech(HTS_Engine * engine, size_t index);
 
 /* HTS_Engine_synthesize_from_fn: synthesize speech from file name */
-DLLEXPORT HTS_Boolean HTS_Engine_synthesize_from_fn(HTS_Engine * engine, const char *fn);
+HTS_API HTS_Boolean HTS_Engine_synthesize_from_fn(HTS_Engine * engine, const char *fn);
 
 /* HTS_Engine_synthesize_from_strings: synthesize speech from string list */
-DLLEXPORT HTS_Boolean HTS_Engine_synthesize_from_strings(HTS_Engine * engine, char **lines, size_t num_lines);
+HTS_API HTS_Boolean HTS_Engine_synthesize_from_strings(HTS_Engine * engine, char **lines, size_t num_lines);
 
 /* HTS_Engine_generate_state_sequence_from_fn: generate state sequence from file name (1st synthesis step) */
-DLLEXPORT HTS_Boolean HTS_Engine_generate_state_sequence_from_fn(HTS_Engine * engine, const char *fn);
+HTS_API HTS_Boolean HTS_Engine_generate_state_sequence_from_fn(HTS_Engine * engine, const char *fn);
 
 /* HTS_Engine_generate_state_sequence_from_strings: generate state sequence from string list (1st synthesis step) */
-DLLEXPORT HTS_Boolean HTS_Engine_generate_state_sequence_from_strings(HTS_Engine * engine, char **lines, size_t num_lines);
+HTS_API HTS_Boolean HTS_Engine_generate_state_sequence_from_strings(HTS_Engine * engine, char **lines, size_t num_lines);
 
 /* HTS_Engine_generate_parameter_sequence: generate parameter sequence (2nd synthesis step) */
-DLLEXPORT HTS_Boolean HTS_Engine_generate_parameter_sequence(HTS_Engine * engine);
+HTS_API HTS_Boolean HTS_Engine_generate_parameter_sequence(HTS_Engine * engine);
 
 /* HTS_Engine_generate_sample_sequence: generate sample sequence (3rd synthesis step) */
-DLLEXPORT HTS_Boolean HTS_Engine_generate_sample_sequence(HTS_Engine * engine);
+HTS_API HTS_Boolean HTS_Engine_generate_sample_sequence(HTS_Engine * engine);
 
 /* HTS_Engine_save_information: save trace information */
-DLLEXPORT void HTS_Engine_save_information(HTS_Engine * engine, FILE * fp);
+HTS_API void HTS_Engine_save_information(HTS_Engine * engine, FILE * fp);
 
 /* HTS_Engine_save_label: save label with time */
-DLLEXPORT void HTS_Engine_save_label(HTS_Engine * engine, FILE * fp);
+HTS_API void HTS_Engine_save_label(HTS_Engine * engine, FILE * fp);
 
 /* HTS_Engine_save_generated_parameter: save generated parameter */
-DLLEXPORT void HTS_Engine_save_generated_parameter(HTS_Engine * engine, size_t stream_index, FILE * fp);
+HTS_API void HTS_Engine_save_generated_parameter(HTS_Engine * engine, size_t stream_index, FILE * fp);
 
 /* HTS_Engine_save_generated_speech: save generated speech */
-DLLEXPORT void HTS_Engine_save_generated_speech(HTS_Engine * engine, FILE * fp);
+HTS_API void HTS_Engine_save_generated_speech(HTS_Engine * engine, FILE * fp);
 
 /* HTS_Engine_save_riff: save RIFF format file */
-DLLEXPORT void HTS_Engine_save_riff(HTS_Engine * engine, FILE * fp);
+HTS_API void HTS_Engine_save_riff(HTS_Engine * engine, FILE * fp);
 
 /* HTS_Engine_refresh: free memory per one time synthesis */
-DLLEXPORT void HTS_Engine_refresh(HTS_Engine * engine);
+HTS_API void HTS_Engine_refresh(HTS_Engine * engine);
 
 /* HTS_Engine_clear: free engine */
-DLLEXPORT void HTS_Engine_clear(HTS_Engine * engine);
+HTS_API void HTS_Engine_clear(HTS_Engine * engine);
 
 HTS_ENGINE_H_END;
 


### PR DESCRIPTION
1. The name must not be generic one, it may cause issues when including headers into another library.
2. It seems that the macrodef enabling symbols exporting was forgotten.